### PR TITLE
feat(reviews): add user review endpoints (one per hotel, list & fetch…

### DIFF
--- a/server/src/controller/hotelController.ts
+++ b/server/src/controller/hotelController.ts
@@ -1,10 +1,13 @@
+// src/controller/hotelController.ts
 import { Request, Response, NextFunction } from "express";
 import mongoose, { Types } from "mongoose";
 import { z } from "zod";
 import { HotelModel } from "../models/Hotel";
 import { ReservationModel } from "../models/Reservation";
+import { ReviewModel } from "../models/Review";
 import { AuthedRequest } from "../middlewares/auth";
 
+// ---------- Zod DTOs ----------
 const roomSchema = z.object({
   roomType: z.enum(["STANDARD", "DELUXE", "SUITE"]),
   pricePerNight: z.number().nonnegative(),
@@ -21,23 +24,52 @@ const createHotelSchema = z.object({
       coordinates: z.tuple([z.number(), z.number()]), // [lng, lat]
     })
     .optional(),
+  title: z.string().optional(),
   description: z.string().optional(),
   amenities: z.array(z.string()).optional(),
   images: z.array(z.string()).optional(),
+  categories: z.array(z.string()).optional(),
   rooms: z.array(roomSchema).min(1),
 });
 
 const updateHotelSchema = createHotelSchema.partial();
 
-// Create
+const reviewCreateSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(2000).optional().default(""),
+});
+
+const reviewUpdateSchema = reviewCreateSchema.partial();
+
+// ---------- Helpers ----------
+async function recomputeHotelRating(hotelId: string | Types.ObjectId) {
+  const agg = await ReviewModel.aggregate<{ _id: null; avg: number; count: number }>([
+    { $match: { hotel: new Types.ObjectId(hotelId) } },
+    {
+      $group: {
+        _id: null,
+        avg: { $avg: "$rating" },
+        count: { $sum: 1 },
+      },
+    },
+  ]);
+
+  const avg = agg[0]?.avg ?? 0;
+  const count = agg[0]?.count ?? 0;
+
+  await HotelModel.findByIdAndUpdate(hotelId, {
+    ratingAvg: Number(avg.toFixed(2)),
+    ratingCount: count,
+  });
+}
+
+// ---------- Create ----------
 export async function createHotel(req: AuthedRequest, res: Response, next: NextFunction) {
   try {
     const dto = createHotelSchema.parse(req.body);
     const doc = await HotelModel.create({
       ...dto,
-      location: dto.location
-        ? { type: "Point", coordinates: dto.location.coordinates }
-        : undefined,
+      location: dto.location ? { type: "Point", coordinates: dto.location.coordinates } : undefined,
       owner: req.user?.id,
     });
     res.status(201).json(doc);
@@ -46,14 +78,21 @@ export async function createHotel(req: AuthedRequest, res: Response, next: NextF
   }
 }
 
-// List with basic filters: q (text), city, minPrice, maxPrice, roomType
+// ---------- List (filters: q, city, roomType, minPrice, maxPrice, category) ----------
 export async function listHotels(req: Request, res: Response, next: NextFunction) {
   try {
-    const { q, city, roomType, minPrice, maxPrice } = req.query as Record<string, string | undefined>;
+    const { q, city, roomType, minPrice, maxPrice, category } = req.query as Record<
+      string,
+      string | undefined
+    >;
 
     const filter: any = {};
     if (q) filter.$text = { $search: q };
     if (city) filter.city = city;
+
+    if (category) {
+      filter.categories = { $in: category.split(",").map((s) => s.trim()).filter(Boolean) };
+    }
 
     const priceClauses: any[] = [];
     if (minPrice) priceClauses.push({ "rooms.pricePerNight": { $gte: Number(minPrice) } });
@@ -62,14 +101,16 @@ export async function listHotels(req: Request, res: Response, next: NextFunction
 
     if (roomType) filter["rooms.roomType"] = roomType;
 
-    const hotels = await HotelModel.find(filter).sort({ ratingAvg: -1, createdAt: -1 }).lean();
+    const hotels = await HotelModel.find(filter)
+      .sort({ ratingAvg: -1, createdAt: -1 })
+      .lean();
     res.json(hotels);
   } catch (err) {
     next(err);
   }
 }
 
-// Read
+// ---------- Read ----------
 export async function getHotelById(req: Request, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
@@ -83,7 +124,7 @@ export async function getHotelById(req: Request, res: Response, next: NextFuncti
   }
 }
 
-// Update (owner/admin)
+// ---------- Update (owner/admin) ----------
 export async function updateHotel(req: AuthedRequest, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
@@ -107,7 +148,7 @@ export async function updateHotel(req: AuthedRequest, res: Response, next: NextF
   }
 }
 
-// Delete (owner/admin)
+// ---------- Delete (owner/admin) ----------
 export async function deleteHotel(req: AuthedRequest, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
@@ -123,6 +164,7 @@ export async function deleteHotel(req: AuthedRequest, res: Response, next: NextF
   }
 }
 
+// ---------- Availability ----------
 // GET /api/hotels/:hotelId/availability?roomType=SUITE&from=2025-09-10&to=2025-09-12
 export async function getAvailability(req: Request, res: Response, next: NextFunction) {
   try {
@@ -176,6 +218,170 @@ export async function getAvailability(req: Request, res: Response, next: NextFun
       available,
       pricePerNight: roomInfo.pricePerNight,
     });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ---------- Reviews ----------
+
+// --- My reviews: list all of the authenticated user's reviews ---
+export async function getMyReviews(req: AuthedRequest, res: Response, next: NextFunction) {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const { page = "1", limit = "10" } = req.query as Record<string, string>;
+    const p = Math.max(1, parseInt(page, 10) || 1);
+    const l = Math.max(1, Math.min(100, parseInt(limit, 10) || 10));
+
+    const [items, total] = await Promise.all([
+      ReviewModel.find({ user: userId })
+        .populate({ path: "hotel", select: "name city ratingAvg ratingCount images" })
+        .sort({ createdAt: -1 })
+        .skip((p - 1) * l)
+        .limit(l)
+        .lean(),
+      ReviewModel.countDocuments({ user: userId }),
+    ]);
+
+    res.json({
+      items,
+      page: p,
+      limit: l,
+      total,
+      pages: Math.ceil(total / l),
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// --- My review for specific hotel ---
+export async function getMyReviewForHotel(req: AuthedRequest, res: Response, next: NextFunction) {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const { hotelId } = req.params;
+    if (!mongoose.isValidObjectId(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+
+    const review = await ReviewModel.findOne({ hotel: hotelId, user: userId })
+      .populate({ path: "hotel", select: "name city ratingAvg ratingCount images" })
+      .lean();
+
+    if (!review) return res.status(404).json({ error: "Review not found" });
+    res.json(review);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// POST /api/hotels/:hotelId/reviews  (create; only one per user per hotel)
+export async function createReview(req: AuthedRequest, res: Response, next: NextFunction) {
+  try {
+    const { hotelId } = req.params;
+    if (!mongoose.isValidObjectId(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const dto = reviewCreateSchema.parse(req.body);
+
+    // Enforce one review per user per hotel
+    const exists = await ReviewModel.findOne({ hotel: hotelId, user: userId }).lean();
+    if (exists) return res.status(409).json({ error: "User already reviewed this hotel" });
+
+    const review = await ReviewModel.create({
+      hotel: hotelId,
+      user: userId,
+      rating: dto.rating,
+      comment: dto.comment,
+    });
+
+    // Attach to hotel.reviews (optional; can be derived)
+    await HotelModel.findByIdAndUpdate(hotelId, { $addToSet: { reviews: review._id } });
+
+    await recomputeHotelRating(hotelId);
+
+    res.status(201).json(review);
+  } catch (err) {
+    // unique index safety net
+    if ((err as any)?.code === 11000) {
+      return res.status(409).json({ error: "User already reviewed this hotel" });
+    }
+    next(err);
+  }
+}
+
+// PATCH /api/hotels/:hotelId/reviews/me  (update own review)
+export async function updateMyReview(req: AuthedRequest, res: Response, next: NextFunction) {
+  try {
+    const { hotelId } = req.params;
+    if (!mongoose.isValidObjectId(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const dto = reviewUpdateSchema.parse(req.body);
+
+    const review = await ReviewModel.findOneAndUpdate(
+      { hotel: hotelId, user: userId },
+      { $set: { ...dto } },
+      { new: true }
+    );
+    if (!review) return res.status(404).json({ error: "Review not found" });
+
+    await recomputeHotelRating(hotelId);
+
+    res.json(review);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// DELETE /api/hotels/:hotelId/reviews/me  (delete own review)
+export async function deleteMyReview(req: AuthedRequest, res: Response, next: NextFunction) {
+  try {
+    const { hotelId } = req.params;
+    if (!mongoose.isValidObjectId(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const review = await ReviewModel.findOneAndDelete({ hotel: hotelId, user: userId });
+    if (!review) return res.status(404).json({ error: "Review not found" });
+
+    // Optionally remove from hotel.reviews
+    await HotelModel.findByIdAndUpdate(hotelId, { $pull: { reviews: review._id } });
+
+    await recomputeHotelRating(hotelId);
+
+    res.json({ message: "Review deleted" });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// GET /api/hotels/:hotelId/reviews  (list)
+export async function listReviews(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { hotelId } = req.params;
+    if (!mongoose.isValidObjectId(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+
+    const reviews = await ReviewModel.find({ hotel: hotelId })
+      .populate({ path: "user", select: "name _id" })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    res.json(reviews);
   } catch (err) {
     next(err);
   }

--- a/server/src/models/Hotel.ts
+++ b/server/src/models/Hotel.ts
@@ -1,13 +1,11 @@
+// src/models/Hotel.ts
 import { Schema, model } from "mongoose";
-
-export type RoomKind = "STANDARD" | "DELUXE" | "SUITE";
 
 const RoomSchema = new Schema(
   {
     roomType: { type: String, enum: ["STANDARD", "DELUXE", "SUITE"], required: true },
     pricePerNight: { type: Number, required: true, min: 0 },
     totalRooms: { type: Number, required: true, min: 0 },
-    // optional bookkeeping field; availability מחושב מריזרביישנים, לא חובה להשתמש
     availableRooms: { type: Number, min: 0, default: undefined },
   },
   { _id: false }
@@ -18,28 +16,28 @@ const HotelSchema = new Schema(
     name: { type: String, required: true, trim: true, index: true },
     city: { type: String, required: true, trim: true, index: true },
     address: { type: String, required: true, trim: true },
-
     location: {
       type: { type: String, enum: ["Point"], default: "Point" },
-      coordinates: { type: [Number], default: undefined }, // [lng, lat]
+      coordinates: { type: [Number] }, // [lng, lat]
     },
-
+    title: { type: String, default: "" },
     description: { type: String, default: "" },
     amenities: { type: [String], default: [] },
     images: { type: [String], default: [] },
-
     rooms: { type: [RoomSchema], default: [] },
-
     ratingAvg: { type: Number, default: 0, min: 0, max: 5 },
     ratingCount: { type: Number, default: 0, min: 0 },
-
+    categories: { type: [String], default: [] },
+    reviews: [{ type: Schema.Types.ObjectId, ref: "Review", default: [] }],
     owner: { type: Schema.Types.ObjectId, ref: "User", index: true },
   },
   { timestamps: true, collection: "hotels" }
 );
 
-// Indexes
 HotelSchema.index({ location: "2dsphere" });
-HotelSchema.index({ name: "text", city: "text", address: "text", description: "text" });
+HotelSchema.index(
+  { name: "text", city: "text", address: "text", description: "text" },
+  { weights: { name: 5, city: 3, address: 2, description: 1 } }
+);
 
 export const HotelModel = model("Hotel", HotelSchema);

--- a/server/src/models/Review.ts
+++ b/server/src/models/Review.ts
@@ -1,0 +1,17 @@
+// src/models/Review.ts
+import { Schema, model } from "mongoose";
+
+const ReviewSchema = new Schema(
+  {
+    hotel: { type: Schema.Types.ObjectId, ref: "Hotel", required: true, index: true },
+    user: { type: Schema.Types.ObjectId, ref: "User", required: true, index: true },
+    rating: { type: Number, min: 1, max: 5, required: true },
+    comment: { type: String, default: "" },
+  },
+  { timestamps: true, collection: "reviews" }
+);
+
+// One review per user per hotel
+ReviewSchema.index({ hotel: 1, user: 1 }, { unique: true });
+
+export const ReviewModel = model("Review", ReviewSchema);

--- a/server/src/routes/hotels.ts
+++ b/server/src/routes/hotels.ts
@@ -6,6 +6,11 @@ import {
   updateHotel,
   deleteHotel,
   getAvailability,
+  createReview,
+  updateMyReview,
+  deleteMyReview,
+  listReviews,
+  getMyReviewForHotel,  // ← add this import
 } from "../controller/hotelController";
 import { requireAuth } from "../middlewares/auth";
 
@@ -15,10 +20,19 @@ const router = Router();
 router.get("/", listHotels);
 router.get("/:id", getHotelById);
 router.get("/:hotelId/availability", getAvailability);
+router.get("/:hotelId/reviews", listReviews);
 
-// Protected (typically owner/admin)
+// Reviews: user-scoped but hotel-specific
+router.get("/:hotelId/reviews/me", requireAuth, getMyReviewForHotel); // ← add this route
+
+// Protected (hotel admin/owner actions)
 router.post("/", requireAuth, createHotel);
 router.put("/:id", requireAuth, updateHotel);
 router.delete("/:id", requireAuth, deleteHotel);
+
+// Review CRUD for the authenticated user
+router.post("/:hotelId/reviews", requireAuth, createReview);
+router.patch("/:hotelId/reviews/me", requireAuth, updateMyReview);
+router.delete("/:hotelId/reviews/me", requireAuth, deleteMyReview);
 
 export default router;

--- a/server/src/routes/me.ts
+++ b/server/src/routes/me.ts
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import { requireAuth, AuthedRequest } from "../middlewares/auth";
 import { UserModel } from "../models/User";
+import { getMyReviews } from "../controller/hotelController";
 
 const router = Router();
 
-router.get("/me", requireAuth, async (req: AuthedRequest, res, next) => {
+// GET /api/me
+router.get("/", requireAuth, async (req: AuthedRequest, res, next) => {
   try {
     const me = await UserModel.findById(req.user!.id).lean();
     if (!me) return res.status(404).json({ error: "User not found" });
@@ -13,5 +15,8 @@ router.get("/me", requireAuth, async (req: AuthedRequest, res, next) => {
     next(err);
   }
 });
+
+// GET /api/me/reviews  → all my reviews (paginated)
+router.get("/reviews", requireAuth, getMyReviews);
 
 export default router;


### PR DESCRIPTION
… own)

- Added ReviewModel with unique index (hotel,user) to enforce one review per user per hotel
- Implemented controller helpers: • getMyReviews → list all reviews by the authenticated user (with pagination) • getMyReviewForHotel → fetch the authenticated user’s review for a specific hotel
- Updated routes: • /api/me/reviews → returns all reviews of the logged-in user • /api/hotels/:hotelId/reviews/me → returns the logged-in user’s review for that hotel
- Wired into meRoutes and hotelsRoutes
- Ensured ratingAvg and ratingCount are recomputed on review create/update/delete